### PR TITLE
Add bypass flag to see the original article while using the auto-redirect userscript

### DIFF
--- a/server/templates/post.html
+++ b/server/templates/post.html
@@ -20,7 +20,7 @@
     <div class="w-full px-4 md:px-6 text-xl text-gray-800 leading-normal" style="font-family:Georgia,serif;">
         <div class="font-sans">
             <p class="text-base md:text-sm text-green-500 font-bold pb-3">
-                <a href="{{ url }}" class="text-sm md:text-sm text-green-500 font-bold no-underline hover:underline ">&lt; Go to the original</a>
+                <a href="{{ url }}#bypass" class="text-sm md:text-sm text-green-500 font-bold no-underline hover:underline ">&lt; Go to the original</a>
             </p>
             {% if previewImageId %}
                 <img alt="Preview image"


### PR DESCRIPTION
Hey! Hope you're doing well @ZhymabekRoman!

This is a feature request to allow users of [medium.user.js](https://gist.github.com/mathix420/e0604ab0e916622972372711d2829555) to see the original medium article.

I thought of adding a hash URL parameter like `#bypass` or maybe something less obvious like `#cfd` to the end of the medium URL. Allowing the userscript to bypass the redirection for these URLs.

I will then update the userscript accordingly.