### PR TITLE
Updated style of the two issue buttons at the bottom of the post page

### DIFF
--- a/server/templates/post.html
+++ b/server/templates/post.html
@@ -1,19 +1,19 @@
 <div class="fixed bottom-4 left-4" style="z-index: 999999;">
     <button onclick="navigateNoCache()"
-            class="m-1.5 flex items-center bg-blue-500 text-white py-2 px-4 rounded-full shadow-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500">
-        <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512">
+            class="group m-1.5 flex items-center rounded-full bg-blue-500 px-4 py-4 text-white shadow-lg transition-all hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4" viewBox="0 0 512 512">
             <!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><style>svg{fill:#ffffff}</style>
             <path d="M463.5 224H472c13.3 0 24-10.7 24-24V72c0-9.7-5.8-18.5-14.8-22.2s-19.3-1.7-26.2 5.2L413.4 96.6c-87.6-86.5-228.7-86.2-315.8 1c-87.5 87.5-87.5 229.3 0 316.8s229.3 87.5 316.8 0c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0c-62.5 62.5-163.8 62.5-226.3 0s-62.5-163.8 0-226.3c62.2-62.2 162.7-62.5 225.3-1L327 183c-6.9 6.9-8.9 17.2-5.2 26.2s12.5 14.8 22.2 14.8H463.5z" />
         </svg>
-        <span class="pl-1.5">problem with displaying post? click there</span>
+        <span class="hidden max-h-4 items-center pl-3 group-hover:flex">problem with displaying post? click there</span>
     </button>
     <button id="openProblemModal"
-            class="m-1.5 flex items-center bg-red-500 text-white py-2 px-4 rounded-full shadow-lg hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-blue-500">
-        <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512">
+            class="group m-1.5 flex items-center rounded-full bg-red-500 px-4 py-4 text-white shadow-lg transition-all hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4" viewBox="0 0 512 512">
             <!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><style>svg{fill:#ffffff}</style>
             <path d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24V296c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224a32 32 0 1 0 -64 0 32 32 0 1 0 64 0z" />
         </svg>
-        <span class="pl-1.5">report problem</span>
+        <span class="hidden max-h-4 items-center pl-3 group-hover:flex">report problem</span>
     </button>
 </div>
 <div class="container w-full md:max-w-3xl mx-auto pt-20 break-words">

--- a/server/templates/post.html
+++ b/server/templates/post.html
@@ -5,7 +5,7 @@
             <!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><style>svg{fill:#ffffff}</style>
             <path d="M463.5 224H472c13.3 0 24-10.7 24-24V72c0-9.7-5.8-18.5-14.8-22.2s-19.3-1.7-26.2 5.2L413.4 96.6c-87.6-86.5-228.7-86.2-315.8 1c-87.5 87.5-87.5 229.3 0 316.8s229.3 87.5 316.8 0c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0c-62.5 62.5-163.8 62.5-226.3 0s-62.5-163.8 0-226.3c62.2-62.2 162.7-62.5 225.3-1L327 183c-6.9 6.9-8.9 17.2-5.2 26.2s12.5 14.8 22.2 14.8H463.5z" />
         </svg>
-        <span class="hidden max-h-4 items-center pl-3 group-hover:flex">problem with displaying post? click there</span>
+        <span class="hidden max-h-4 items-center pl-3 group-hover:flex group-focus-visible:flex">problem with displaying post? click there</span>
     </button>
     <button id="openProblemModal"
             class="group m-1.5 flex items-center rounded-full bg-red-500 px-4 py-4 text-white shadow-lg transition-all hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500">
@@ -13,7 +13,7 @@
             <!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><style>svg{fill:#ffffff}</style>
             <path d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24V296c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224a32 32 0 1 0 -64 0 32 32 0 1 0 64 0z" />
         </svg>
-        <span class="hidden max-h-4 items-center pl-3 group-hover:flex">report problem</span>
+        <span class="hidden max-h-4 items-center pl-3 group-hover:flex group-focus-visible:flex">report problem</span>
     </button>
 </div>
 <div class="container w-full md:max-w-3xl mx-auto pt-20 break-words">


### PR DESCRIPTION
Retracted buttons and expended when hovering. I feel like it's enough UX friendly for mobile too, as the icons are pretty much self describing, but ofc you decide.

![image](https://github.com/Freedium-cfd/web/assets/37625778/b0e862aa-5932-4755-8136-fcba18ab37dc)
![image](https://github.com/Freedium-cfd/web/assets/37625778/7c805379-b77a-4c7d-97d3-d996836fbdd6)

Playground: https://play.tailwindcss.com/L6CqTbZSkC

Edit: just added better keyboard navigation support (focus-within)